### PR TITLE
Dodanie metody Zakoncz() do obiektu COM

### DIFF
--- a/public/api/index.php
+++ b/public/api/index.php
@@ -88,6 +88,9 @@ try {
 
 	$json_response['state'] = 'success';
 	$json_response['data']	 = $result;
+	
+	$subiektGtCom->Zakoncz();
+	
 	Logger::getInstance()->log('api', 'Request finish: ' . $_SERVER['REMOTE_ADDR'], $class . '->' . $method, __LINE__);
 } catch (Exception $e) {
 	$json_response['state'] = 'fail';


### PR DESCRIPTION
Gdy nie wywołamy tej metody to w Subiekt GT w wersji 1.6 uruchomiony proces SubiektGT.exe nie zostanie zakończony.
Przy wielu wywołaniach API pozostawione procesy będą cały czas działać w tle co w końcu spowoduje brak pamięci.